### PR TITLE
New bettercodehub yml

### DIFF
--- a/.bettercodehub.yml
+++ b/.bettercodehub.yml
@@ -1,6 +1,6 @@
 exclude:
 - /tests/FQCNReaderTest.php
-component_depth: 5
+component_depth: 1
 languages:
 - php
 

--- a/.bettercodehub.yml
+++ b/.bettercodehub.yml
@@ -1,0 +1,6 @@
+exclude:
+- /blob/master/tests/FQCNReaderTest.php
+component_depth: 5
+languages:
+- php
+

--- a/.bettercodehub.yml
+++ b/.bettercodehub.yml
@@ -3,4 +3,3 @@ exclude:
 component_depth: 1
 languages:
 - php
-

--- a/.bettercodehub.yml
+++ b/.bettercodehub.yml
@@ -1,5 +1,5 @@
 exclude:
-- /blob/master/tests/FQCNReaderTest.php
+- /tests/FQCNReaderTest.php
 component_depth: 5
 languages:
 - php

--- a/bettercodehub.yml
+++ b/bettercodehub.yml
@@ -1,4 +1,0 @@
-component_depth: 5
-languages:
-- php
-


### PR DESCRIPTION
Hi @jasny we found the reason why BetterCodeHub.com failed for this repo. A concept called Heredoc is used in FQCNReaderTest, we do analyse that in other technologies, but as you show our PHP analysis needs to be adapted to handle that concept well. A temp solution is to filter out the file /tests/FQCNReaderTest.php. In this pull request I added the code that excludes this test file and I added the mandatory **dot** in front of the .bettercodehub.yml file. ps Your BCH score fails on only one architecture guideline, unfortunately that is currently the case for these tiny repos.