### PR TITLE
Fix for Issue #3

### DIFF
--- a/src/FQCNReader.php
+++ b/src/FQCNReader.php
@@ -22,10 +22,11 @@ class FQCNReader
 
         while (!isset($class) && !feof($fp)) {
             $buffer .= fread($fp, 512);
-
-            if (strpos($buffer, '{') === false) {
+            $openingBracePosition = strpos($buffer, '{');
+            if ($openingBracePosition === false) {
                 continue;
             }
+            $buffer = substr($buffer, 0, $openingBracePosition + 1) . '}';
 
             $tokens = token_get_all($buffer);
             $class = $this->getFqcnFromTokens($tokens);

--- a/tests/FQCNReaderTest.php
+++ b/tests/FQCNReaderTest.php
@@ -69,6 +69,64 @@ PHP;
         $this->assertEquals('Foo\\Bar', $this->fqcnReader->getClass('vfs://root/test.php'));
     }
 
+    /**
+     * Test case reproduces a bug that may happen due to buffering issues
+     */
+    public function testGetClassNsWarningIssue()
+    {
+        $source = <<<PHP
+<?php
+/*
+ * ggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+ * ggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+ * gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+ * gggggggggggggggggggggggggggg
+ * ggggggggggggggggggg
+ */
+
+namespace Slenderman\Core\Services;
+
+use Monolog\Formatter\HtmlFormatter;
+use Monolog\Formatter\LineFormatter;
+use Slenderman\Services\Contracts\ServiceProviderInterface;
+use const APP_ROOT;
+use function DI\add;
+use function DI\get;
+
+/**
+ * Contains settings that are for the whole app that do not change based on the mode
+ *
+ * @author Aesonus <corylcomposinger at gmail.com>
+ */
+class AppSettingsService implements ServiceProviderInterface
+{
+    /**
+     * Log handling settings
+     */
+    const LOG_HANDLER_SETTINGS = 'log_handler_settings';
+
+    /**
+     * Log handler settings for errors in html format
+     */
+    const LOG_HANDLER_SETTINGS_HTML = 'html_errors';
+
+    /**
+     * Log handler settings for errors in text line format
+     */
+    const LOG_HANDLER_SETTINGS_TEXT = 'text_errors';
+
+    /**
+     * The stream definition for a log handler
+     */
+    const LOG_HANDLER_STREAM = 'stream';
+}
+?>
+PHP;
+        $this->root->addChild(vfsStream::newFile('test.php')->setContent($source));
+
+        $this->assertEquals('Slenderman\\Core\\Services\\AppSettingsService', $this->fqcnReader->getClass('vfs://root/test.php'));
+    }
+
     public function testGetClassLongComment()
     {
         $docblock = "\n" . str_repeat(" * I am another line of comment\n", 100);

--- a/tests/FQCNReaderTest.php
+++ b/tests/FQCNReaderTest.php
@@ -72,7 +72,7 @@ PHP;
     /**
      * Test case reproduces a bug that may happen due to buffering issues
      */
-    public function testGetClassNsWarningIssue()
+    public function testGetClassNsWarningInIssueNumber3()
     {
         $source = <<<PHP
 <?php


### PR DESCRIPTION
This would fix the warning issue by truncating the part of the class that isn't needed to determine the fully qualified class name.